### PR TITLE
fix: avoid eval inside pr title

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,8 +59,8 @@ git_cmd git cherry-pick "${GITHUB_SHA}"
 if [ $? -eq 0 ]; then
   echo "git cherry-pick succeeded. We will create a pull request for it."
   git_cmd git push -u origin "${PR_BRANCH}"
-  git_cmd hub pull-request -b "${INPUT_PR_BRANCH}" -h "${PR_BRANCH}" -l "${INPUT_PR_LABELS}" -a "${GITHUB_ACTOR}" -m "\"${PR_TITLE}\"" -m "\"${INPUT_PR_BODY}\"" -r "${GITHUB_ACTOR}"
+  git_cmd hub pull-request -b "${INPUT_PR_BRANCH}" -h "${PR_BRANCH}" -l "${INPUT_PR_LABELS}" -a "${GITHUB_ACTOR}" -m "'${PR_TITLE}'" -m "'${INPUT_PR_BODY}'" -r "${GITHUB_ACTOR}"
 else
   echo "git cherry-pick failed. We will create an issue for it."
-  git_cmd hub issue create -m "\"cherrypick ${PR_TITLE} to branch ${INPUT_PR_BRANCH}\"" -m "\"${INPUT_PR_BODY}\"" -a "${GITHUB_ACTOR}" -l "${INPUT_PR_LABELS}"
+  git_cmd hub issue create -m "'cherrypick ${PR_TITLE} to branch ${INPUT_PR_BRANCH}'" -m "'${INPUT_PR_BODY}'" -a "${GITHUB_ACTOR}" -l "${INPUT_PR_LABELS}"
 fi


### PR DESCRIPTION
Had to create https://github.com/risingwavelabs/risingwave/pull/15281 manually due backticks in title (`if not exists`).

It has also been observed that other cherry-pick PRs lost content inside backticks.

Note the following (both in bash & zsh):
```
$ export PR_TITLE='testing `whoami` command'
$ echo ${#PR_TITLE}
24
$ echo "${PR_TITLE}"
testing `whoami` command

$ eval echo "\"${PR_TITLE}\""
testing xiangjin command
$ eval echo "'${PR_TITLE}'"
testing `whoami` command
```

Tested:
https://github.com/risingwavelabs/risingwave/pull/15442
https://github.com/risingwavelabs/risingwave/actions/runs/8151543257/job/22279557984

* `test-cherry-pick-action-base` contains the modified workflow/job to use script from `fix-pr-title-eval-backtick`
* PRs are merged into `test-cherry-pick-action-source` and the action creates cherry-pick PRs for `test-cherry-pick-action-target`.