### PR TITLE
remove eval to avoid eval with single/double/back quote

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ git_cmd() {
   else
     echo "This is NOT a dry run. We output and execute the command:"
     echo $@
-    eval $@
+    "$@"
   fi
 }
 
@@ -62,8 +62,8 @@ git_cmd git cherry-pick "${GITHUB_SHA}"
 if [ $? -eq 0 ]; then
   echo "git cherry-pick succeeded. We will create a pull request for it."
   git_cmd git push -u origin "${PR_BRANCH}"
-  git_cmd hub pull-request -b "${INPUT_PR_BRANCH}" -h "${PR_BRANCH}" -l "${INPUT_PR_LABELS}" -a "${GITHUB_ACTOR}" -m "'${PR_TITLE}'" -m "'${INPUT_PR_BODY}'" -r "${GITHUB_ACTOR}"
+  git_cmd hub pull-request -b "${INPUT_PR_BRANCH}" -h "${PR_BRANCH}" -l "${INPUT_PR_LABELS}" -a "${GITHUB_ACTOR}" -m "${PR_TITLE}" -m "${INPUT_PR_BODY}" -r "${GITHUB_ACTOR}"
 else
   echo "git cherry-pick failed. We will create an issue for it."
-  git_cmd hub issue create -m "'cherrypick ${PR_TITLE} to branch ${INPUT_PR_BRANCH}'" -m "'${INPUT_PR_BODY}'" -a "${GITHUB_ACTOR}" -l "${INPUT_PR_LABELS}"
+  git_cmd hub issue create -m "cherrypick ${PR_TITLE} to branch ${INPUT_PR_BRANCH}" -m "${INPUT_PR_BODY}" -a "${GITHUB_ACTOR}" -l "${INPUT_PR_LABELS}"
 fi


### PR DESCRIPTION
```
bash-5.2$ cat /tmp/test.sh
testcmd() {
	echo "$@"
	"$@"
}

export PR_TITLE='testing `whoami` command'
testcmd echo "$PR_TITLE"
export PR_TITLE='testing "whoami" command'
testcmd echo "$PR_TITLE"
export PR_TITLE="testing 'whoami' command"
testcmd echo "$PR_TITLE"
bash-5.2$ bash /tmp/test.sh
echo testing `whoami` command
testing `whoami` command
echo testing "whoami" command
testing "whoami" command
echo testing 'whoami' command
testing 'whoami' command
```