### PR TITLE
fix: emit Jarvis cherry-pick conflict tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ developers works on but we want to push the changes to the Release branches too.
 * Create a new pr branch Z on the branch Y
 * Cherry Pick the commits from X into Z
 * If the cherry-pick succeeds, push the branch and create the PR on base Y
-* If the cherry-pick conflicts, create an issue with conflict-resolution instructions and assign it to Jarvis instead
+* If the cherry-pick conflicts, create an issue with conflict-resolution instructions and a trusted marker that Jarvis can discover
 * PR title will be prefixed with `AUTO`
 
 #### Conditions:
@@ -34,6 +34,12 @@ CSV Labels to apply on the PR created. Default: `autocreated`
 #### `commit_sha`
 
 The specific commit SHA to cherry-pick. If not provided, it defaults to the triggering commit (`GITHUB_SHA`).
+
+#### `source_pr_number`
+
+The original pull request number. It is written into the conflict issue's Jarvis marker. For compatibility, the action can also extract it from a `pr_body` containing `Cherry picking #N onto branch ...`. If neither is available, the action creates a human-only conflict issue without a Jarvis marker.
+
+Jarvis discovery also requires the issue creator and configured label to match its trusted policy. The action intentionally does not assign the Jarvis GitHub App as an issue assignee; a regular GitHub App bot is not an assignable coding agent.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Commit SHA to cherry-pick (defaults to GITHUB_SHA if not provided)'
     required: false
     default: ''
+  source_pr_number:
+    description: 'Original pull request number used to create a trusted Jarvis conflict task'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,6 +78,14 @@ PR_TITLE=$(git log -1 --format="%s" "$COMMIT_SHA")
 echo "PR_TITLE:$PR_TITLE"
 echo "INPUT_PR_BODY:${INPUT_PR_BODY}"
 
+# Prefer the explicit source PR input. Keep compatibility with existing callers
+# whose body uses "Cherry picking #N onto branch ...".
+SOURCE_PR_NUMBER="${INPUT_SOURCE_PR_NUMBER:-}"
+# shellcheck disable=SC3010
+if [[ -z "${SOURCE_PR_NUMBER}" && "${INPUT_PR_BODY}" =~ Cherry[[:space:]]picking[[:space:]]#([0-9]+)[[:space:]]onto[[:space:]]branch ]]; then
+  SOURCE_PR_NUMBER="${BASH_REMATCH[1]}"
+fi
+
 # Add GITHUB_SHA to the PR/issue body
 INPUT_PR_BODY=$(printf "%s\n\nThis PR/issue was created by cherry-pick action from commit %s.", "${INPUT_PR_BODY}", "${COMMIT_SHA}")
 
@@ -106,17 +114,12 @@ else
 
 Run \`git cherry-pick ${COMMIT_SHA}\` first, then resolve any conflicts. Avoid unnecessary improvements and keep the diff as close to the original commit as possible. Target branch: \`${INPUT_PR_BRANCH}\`."
   ISSUE_BODY=$(printf "%s\n\n%s" "${INPUT_PR_BODY}" "${CONFLICT_INSTRUCTIONS}")
+  if [[ "${SOURCE_PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+    JARVIS_MARKER="<!-- jarvis-cherry-pick-conflict:v1 source_pr=${GITHUB_REPOSITORY}#${SOURCE_PR_NUMBER} commit=${COMMIT_SHA} target=${INPUT_PR_BRANCH} -->"
+    ISSUE_BODY=$(printf "%s\n\n%s" "${ISSUE_BODY}" "${JARVIS_MARKER}")
+  else
+    echo "No source PR number was supplied or found in pr_body; creating a human-only conflict issue." >&2
+  fi
   ISSUE_URL=$(git_cmd hub issue create -m "cherry-pick ${PR_TITLE} to branch ${INPUT_PR_BRANCH}" -m "${ISSUE_BODY}" -a "${GITHUB_ACTOR}" -l "${INPUT_PR_LABELS}")
   echo "$ISSUE_URL"
-  CLEAN_URL="${ISSUE_URL//[[:space:]]/}"
-  if [[ -n "$CLEAN_URL" ]]; then
-    ISSUE_NUMBER=${CLEAN_URL##*/}
-    echo "/repos/{owner}/{repo}/issues/${ISSUE_NUMBER}/assignees"
-    # https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/use-agent-apps#starting-an-agent-from-an-issue
-    # https://hub.github.com/hub-api.1.html
-    hub api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-      "/repos/{owner}/{repo}/issues/${ISSUE_NUMBER}/assignees" --input - <<< '{
-      "assignees": ["rw-jarvis-bot[bot]"]
-    }'
-  fi
 fi


### PR DESCRIPTION
## Summary

- emit a versioned, machine-readable marker when a cherry-pick conflict issue is created
- accept an explicit source PR number while retaining compatibility with the existing `Cherry picking #N onto branch ...` body
- remove the unsupported attempt to assign `rw-jarvis-bot[bot]` through the normal assignee API

## Root cause

A regular GitHub App bot is not an assignable coding agent in `risingwavelabs/risingwave`, so the assignee POST returns 403 after the conflict issue is created. Jarvis needs a trusted discovery contract instead of an issue assignment.

## Companion consumer

- risingwavelabs/jarvis-v2#492

## Validation

- `bash -n entrypoint.sh`
- `shellcheck entrypoint.sh`
- `git diff --check`

Collaborated with Jarvis (OpenAI Codex).
